### PR TITLE
fix(cloudflare-pages): respect `outputDir` option

### DIFF
--- a/.changeset/chatty-toes-carry.md
+++ b/.changeset/chatty-toes-carry.md
@@ -1,0 +1,5 @@
+---
+'@hono/vite-cloudflare-pages': patch
+---
+
+fix: respect `outputDir` option

--- a/packages/cloudflare-pages/src/cloudflare-pages.ts
+++ b/packages/cloudflare-pages/src/cloudflare-pages.ts
@@ -47,6 +47,7 @@ export const cloudflarePagesPlugin = (options?: CloudflarePagesOptions): Plugin 
           noExternal: true,
         },
         build: {
+          outDir: options?.outputDir ?? defaultOptions.outputDir,
           emptyOutDir: options?.emptyOutDir ?? defaultOptions.emptyOutDir,
           minify: options?.minify ?? defaultOptions.minify,
           ssr: true,

--- a/packages/cloudflare-pages/test/cloudflare-pages.test.ts
+++ b/packages/cloudflare-pages/test/cloudflare-pages.test.ts
@@ -7,7 +7,6 @@ import cloudflarePagesPlugin from '../src/index'
 describe('cloudflarePagesPlugin', () => {
   const testDir = './test-project'
   const entryFile = `${testDir}/app/server.ts`
-  const outputFile = `${testDir}/dist/_worker.js`
 
   beforeAll(() => {
     fs.mkdirSync(path.dirname(entryFile), { recursive: true })
@@ -19,11 +18,34 @@ describe('cloudflarePagesPlugin', () => {
   })
 
   it('Should build the project correctly with the plugin', async () => {
+    const outputFile = `${testDir}/dist/_worker.js`
+
     expect(fs.existsSync(entryFile)).toBe(true)
 
     await build({
       root: testDir,
       plugins: [cloudflarePagesPlugin()],
+      build: {
+        emptyOutDir: true,
+      },
+    })
+
+    expect(fs.existsSync(outputFile)).toBe(true)
+
+    const output = fs.readFileSync(outputFile, 'utf-8')
+    expect(output).toContain('Hello World')
+  })
+
+  it('Should build the project correctly with custom output directory', async () => {
+    const outputFile = `${testDir}/customDir/_worker.js`
+
+    expect(fs.existsSync(entryFile)).toBe(true)
+
+    await build({
+      root: testDir,
+      plugins: [cloudflarePagesPlugin({
+        outputDir: 'customDir',
+      })],
       build: {
         emptyOutDir: true,
       },


### PR DESCRIPTION
`outputDir` option exists but is not referenced in the production code.

This PR adds `build.outDir` to the plugin config to respect `outputDir` option.