### PR TITLE
fix(dev-server): initialize Miniflare only on the first run

### DIFF
--- a/.changeset/five-emus-develop.md
+++ b/.changeset/five-emus-develop.md
@@ -1,0 +1,5 @@
+---
+"@hono/vite-dev-server": patch
+---
+
+fix: initialize Miniflare only on the first run

--- a/packages/dev-server/src/cloudflare-pages/cloudflare-pages.ts
+++ b/packages/dev-server/src/cloudflare-pages/cloudflare-pages.ts
@@ -21,13 +21,15 @@ const nullScript = 'export default { fetch: () => new Response(null, { status: 4
 let mf: Miniflare | undefined = undefined
 
 export const getEnv: GetEnv<Options> = (options) => async () => {
-  // Dynamic import Miniflare for environments like Bun.
-  const { Miniflare } = await import('miniflare')
-  mf = new Miniflare({
-    modules: true,
-    script: nullScript,
-    ...options,
-  })
+  if (!mf) {
+    // Dynamic import Miniflare for environments like Bun.
+    const { Miniflare } = await import('miniflare')
+    mf = new Miniflare({
+      modules: true,
+      script: nullScript,
+      ...options,
+    })
+  }
 
   const env = {
     ...(await mf.getBindings()),
@@ -48,6 +50,7 @@ export const getEnv: GetEnv<Options> = (options) => async () => {
 
 export const disposeMf = async () => {
   mf?.dispose()
+  mf = undefined
 }
 
 const plugin = (options?: Options): Plugin => {


### PR DESCRIPTION
Fix an issue where Miniflare's initialization process was executed on every access if use `options.cf`  in the `@hono/vite-dev-server` package.
