### PR TITLE
feat(ssg): make it simple

### DIFF
--- a/.changeset/chatty-moose-remain.md
+++ b/.changeset/chatty-moose-remain.md
@@ -1,0 +1,5 @@
+---
+"@hono/vite-ssg": minor
+---
+
+Simplify the build flow. Just run `toSSG`. Respect Vite's config.

--- a/packages/ssg/README.md
+++ b/packages/ssg/README.md
@@ -58,15 +58,8 @@ wrangler pages deploy ./dist
 The options are below.
 
 ```ts
-type BuildConfig = {
-  outputDir?: string
-  publicDir?: string
-}
-
 type SSGOptions = {
   entry?: string
-  rootDir?: string
-  build?: BuildConfig
 }
 ```
 
@@ -75,11 +68,6 @@ Default values:
 ```ts
 const defaultOptions = {
   entry: './src/index.tsx',
-  tempDir: '.hono',
-  build: {
-    outputDir: '../dist',
-    publicDir: '../public',
-  },
 }
 ```
 

--- a/packages/ssg/src/ssg.ts
+++ b/packages/ssg/src/ssg.ts
@@ -40,7 +40,7 @@ export const ssgBuild = (options?: SSGOptions): Plugin => {
     },
     load(id) {
       if (id === resolvedVirtualId) {
-        return ''
+        return 'console.log("suppress empty chunk message")'
       }
     },
     async generateBundle(_outputOptions, bundle) {

--- a/packages/ssg/src/ssg.ts
+++ b/packages/ssg/src/ssg.ts
@@ -77,7 +77,9 @@ export const ssgBuild = (options?: SSGOptions): Plugin => {
               source: data,
             })
           },
-          async mkdir() {},
+          async mkdir() {
+            return
+          },
         },
         { dir: outDir }
       )

--- a/packages/ssg/test/ssg.test.ts
+++ b/packages/ssg/test/ssg.test.ts
@@ -37,4 +37,37 @@ describe('ssgPlugin', () => {
     const output = fs.readFileSync(outputFile, 'utf-8')
     expect(output).toBe('<html><body><h1>Hello!</h1></body></html>')
   })
+
+  it('Should keep other inputs politely', async () => {
+    expect(fs.existsSync(entryFile)).toBe(true)
+
+    await build({
+      plugins: [
+        ssgPlugin({
+          entry: entryFile,
+        }),
+      ],
+      build: {
+        rollupOptions: {
+          input: entryFile,
+          output: {
+            entryFileNames: 'assets/[name].js',
+          },
+        },
+        outDir: path.resolve(testDir, 'dist'),
+        emptyOutDir: true,
+      },
+    })
+
+    const entryOutputFile = path.resolve(testDir, 'dist', 'assets', 'app.js')
+
+    expect(fs.existsSync(outputFile)).toBe(true)
+    expect(fs.existsSync(entryOutputFile)).toBe(true)
+
+    const output = fs.readFileSync(outputFile, 'utf-8')
+    expect(output).toBe('<html><body><h1>Hello!</h1></body></html>')
+
+    const entryOutput = fs.readFileSync(entryOutputFile, 'utf-8')
+    expect(entryOutput.length).toBeGreaterThan(0)
+  })
 })

--- a/packages/ssg/test/ssg.test.ts
+++ b/packages/ssg/test/ssg.test.ts
@@ -7,7 +7,8 @@ import ssgPlugin from '../src/index'
 describe('ssgPlugin', () => {
   const testDir = './test-project'
   const entryFile = './test/app.ts'
-  const outputFile = path.resolve(testDir, 'dist', 'index.html')
+  const outDir = path.resolve(testDir, 'dist')
+  const outputFile = path.resolve(outDir, 'index.html')
 
   beforeAll(() => {
     fs.mkdirSync(testDir, { recursive: true })
@@ -27,7 +28,7 @@ describe('ssgPlugin', () => {
         }),
       ],
       build: {
-        outDir: path.resolve(testDir, 'dist'),
+        outDir,
         emptyOutDir: true,
       },
     })
@@ -36,6 +37,9 @@ describe('ssgPlugin', () => {
 
     const output = fs.readFileSync(outputFile, 'utf-8')
     expect(output).toBe('<html><body><h1>Hello!</h1></body></html>')
+
+    // Should not output files corresponding to a virtual entry
+    expect(fs.existsSync(path.resolve(outDir, 'assets'))).toBe(false)
   })
 
   it('Should keep other inputs politely', async () => {
@@ -54,7 +58,7 @@ describe('ssgPlugin', () => {
             entryFileNames: 'assets/[name].js',
           },
         },
-        outDir: path.resolve(testDir, 'dist'),
+        outDir,
         emptyOutDir: true,
       },
     })

--- a/packages/ssg/test/ssg.test.ts
+++ b/packages/ssg/test/ssg.test.ts
@@ -24,10 +24,10 @@ describe('ssgPlugin', () => {
       plugins: [
         ssgPlugin({
           entry: entryFile,
-          tempDir: path.resolve(testDir, '.hono'),
         }),
       ],
       build: {
+        outDir: path.resolve(testDir, 'dist'),
         emptyOutDir: true,
       },
     })


### PR DESCRIPTION
Based on research in honojs/honox#48

before: Use Vite to build the toSSG generated code. This means that it was built **twice**.
after: Generate a page with toSSG. That's it.