### PR TITLE
Added JSDoc default values to the Cloudflare Pages plugin options

### DIFF
--- a/packages/cloudflare-pages/src/cloudflare-pages.ts
+++ b/packages/cloudflare-pages/src/cloudflare-pages.ts
@@ -3,9 +3,18 @@ import type { Plugin, UserConfig } from 'vite'
 import { getEntryContent } from './entry.js'
 
 type CloudflarePagesOptions = {
+  /**
+   * @default ['./src/index.tsx', './app/server.ts']
+   */ 
   entry?: string | string[]
+  /**
+   * @default './dist'
+   */
   outputDir?: string
   external?: string[]
+  /**
+   * @default true
+   */
   minify?: boolean
   emptyOutDir?: boolean
 }


### PR DESCRIPTION
We are using this plugin over at @lipu-linku, and we recently ran into a problem where the `entry` defaults screwed us over, since we are building a regular REST API, and not a React client side app.

This PR adds very simple JSDoc to the options, to allow users to see their default values in their editor, instead of having to look them up in a subfolder of a monorepo.