### PR TITLE
feat: add `export` option

### DIFF
--- a/.changeset/wicked-starfishes-switch.md
+++ b/.changeset/wicked-starfishes-switch.md
@@ -1,0 +1,5 @@
+---
+"@hono/vite-dev-server": minor
+---
+
+Added `export` property to `devServer`.

--- a/packages/dev-server/README.md
+++ b/packages/dev-server/README.md
@@ -99,6 +99,7 @@ The options are below.
 ```ts
 export type DevServerOptions = {
   entry?: string
+  export?: string
   injectClientScript?: boolean
   exclude?: (string | RegExp)[]
   env?: Env | EnvFunc

--- a/packages/dev-server/src/dev-server.ts
+++ b/packages/dev-server/src/dev-server.ts
@@ -7,6 +7,7 @@ import type { Env, Fetch, EnvFunc, Plugin } from './types.js'
 
 export type DevServerOptions = {
   entry?: string
+  export?: string
   injectClientScript?: boolean
   exclude?: (string | RegExp)[]
   env?: Env | EnvFunc
@@ -22,6 +23,7 @@ export type DevServerOptions = {
 
 export const defaultOptions: Required<Omit<DevServerOptions, 'env' | 'cf'>> = {
   entry: './src/index.ts',
+  export: 'default',
   injectClientScript: true,
   exclude: [
     /.*\.ts$/,
@@ -67,10 +69,11 @@ export function devServer(options?: DevServerOptions): VitePlugin {
             return next(e)
           }
 
-          const app = appModule['default'] as { fetch: Fetch }
+          const exportName = options?.export ?? defaultOptions.export
+          const app = appModule[exportName] as { fetch: Fetch }
 
           if (!app) {
-            return next(new Error(`Failed to find a named export "default" from ${entry}`))
+            return next(new Error(`Failed to find a named export "${exportName}" from ${entry}`))
           }
 
           getRequestListener(


### PR DESCRIPTION
Would be nice if there were a way to configure the export name. This would be useful to avoid conflict in cases where some runtimes (ie. Vercel Serverless) also rely on a default export.

e.g.

```ts
// ./api/index.ts

import { Hono } from 'hono'
import { handle } from 'hono/vercel'

export const runtime = 'edge';

export const app = new Hono().basePath('/api')

app.get('/hello', (c) => {
  return c.json({
    message: 'Hello Vercel!',
  })
})

export const GET = handle(app)
export const POST = handle(app)
```

```ts
// ./vite.config.ts
import devServer from '@hono/vite-dev-server'
import { defineConfig } from 'vite'

export default defineConfig({
  plugins: [
    devServer({
      entry: './api/index.ts',
      export: 'app'
    }),
  ]
})
```