### PR TITLE
fix(dev-server): add `.mf` to `ignoreWatching`

### DIFF
--- a/.changeset/soft-cherries-allow.md
+++ b/.changeset/soft-cherries-allow.md
@@ -1,0 +1,5 @@
+---
+"@hono/vite-dev-server": minor
+---
+
+Added `.mf` to `ignoreWatching` in `vite-plugin` to fix unnecessary server reloads on file changes. This update prevents the Vite server from restarting when `.mf` files are modified, improving development experience.

--- a/packages/dev-server/src/dev-server.ts
+++ b/packages/dev-server/src/dev-server.ts
@@ -64,7 +64,7 @@ export const defaultOptions: Required<Omit<DevServerOptions, 'env' | 'cf' | 'ada
     /^\/static\/.+/,
     /^\/node_modules\/.*/,
   ],
-  ignoreWatching: [/\.wrangler/],
+  ignoreWatching: [/\.wrangler/, /\.mf/],
   plugins: [],
 }
 


### PR DESCRIPTION
The change is minimal, adding `.mf` to `ignoreWatching` in [`vite-plugins/packages/dev-server/src/dev-server.ts`][ref].

[ref]: https://github.com/tseijp/vite-plugins/blob/main/packages/dev-server/src/dev-server.ts

```ts
// dev-server.ts
- ignoreWatching: [/\.wrangler/],
+ ignoreWatching: [/\.wrangler/, /\.mf/],
```

I've been developing with hono-x and cloudflare d1, but frequently encountered vite errors, causing the server to stop many time.

```ruby
warn - No utility classes were detected in your source files. If this is unexpected, double-check the `content` option in your Tailwind CSS configuration.
warn - https://tailwindcss.com/docs/content-configuration
/___/node_modules/wrangler/wrangler-dist/cli.js:29573
            throw a;
            ^

Error: The server is being restarted or closed. Request is outdated
    at throwClosedServerError (file:///___/node_modules/vite/dist/node/chunks/dep-jDlpJiMN.js:50329:17)
    at transformRequest (file:///___/node_modules/vite/dist/node/chunks/dep-jDlpJiMN.js:53416:9)
    at Proxy.warmupRequest (file:///___/node_modules/vite/dist/node/chunks/dep-jDlpJiMN.js:64313:19)
    at file:///___/node_modules/vite/dist/node/chunks/dep-jDlpJiMN.js:65812:32
    at async Promise.all (index 0)
    at async TransformContext.transform (file:///___/node_modules/vite/dist/node/chunks/dep-jDlpJiMN.js:65670:13)
    at async Object.transform (file:///___/node_modules/vite/dist/node/chunks/dep-jDlpJiMN.js:50838:30)
    at async loadAndTransform (file:///___/node_modules/vite/dist/node/chunks/dep-jDlpJiMN.js:53611:29)
    at async viteTransformMiddleware (file:///___/node_modules/vite/dist/node/chunks/dep-jDlpJiMN.js:63409:32) {
  code: 'ERR_CLOSED_SERVER'
}
```

Even without file changes, the vite server kept reloading. Adding `.mf` to `server.watch.ignore` resolved the errors, suggesting `.mf` updates caused clashes.

```ts
...
  return {
    server: {
      watch: {
        ignored: [/\.wrangler/, /\.mf/],
      },
...
```

<details>
<summary>

For reference, I'm using the following `vite.config.ts`. Developing with *react* and *tailwind* on *hono-x* has been very comfortable and enjoyable. Thank you!

</summary>

```ts

import pages from '@hono/vite-cloudflare-pages'
import honox from 'honox/vite'
import { defineConfig } from 'vite'
import { getPlatformProxy } from 'wrangler'

export default defineConfig(async ({ mode }) => {
  if (mode === 'client') {
    return {
      build: {
        rollupOptions: {
          input: ['./app/client.ts', './app/style.css'],
          output: {
            entryFileNames: 'static/client.js',
            chunkFileNames: 'static/assets/[name]-[hash].js',
            assetFileNames: 'static/assets/[name].[ext]',
          },
        },
      },
    }
  } else {
    const { env, dispose } = await getPlatformProxy()

    return {
      server: {
        watch: {
          ignored: [/\.wrangler/, /\.mf/],
        },
      },
      ssr: {
        external: ['react', 'react-dom'],
      },
      plugins: [
        honox({
          devServer: {
            env,
            plugins: [
              {
                onServerClose: dispose,
              },
            ],
          },
        }),
        pages(),
      ],
    }
  }
})
```

I've been using cloudflare pages for a long time and am truly grateful. Typically using AWS or GCP for the backend, discovering hono led me to cloudflare's d1.
Given my limited experience with cloudflare d1, I would appreciate it if you could close my PR if it's off the mark.
Thank you!

</details>
