### PR TITLE
fix(dev-server): `typesVersions` cloudflare adapter

### DIFF
--- a/.changeset/unlucky-peaches-wave.md
+++ b/.changeset/unlucky-peaches-wave.md
@@ -1,0 +1,5 @@
+---
+'@hono/vite-dev-server': patch
+---
+
+fixed typesVersions in `@hono/vite-dev-server/cloudflare`

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -46,7 +46,7 @@
         "./dist/types"
       ],
       "cloudflare": [
-        "./dist/adapter/cloudflare/types"
+        "./dist/adapter/cloudflare.d.ts"
       ],
       "cloudflare-pages": [
         "./dist/cloudflare-pages/index.d.ts"


### PR DESCRIPTION
Fixed a type error when importing with `vite.cofig.ts` due to an incorrect cloudfalre entry in typesVersions in pacakge.json in `@hono/vite-dev-server`.

## checked
- [X] `yarn build`
- [X] `changeset`