### PR TITLE
fix(dev-server): add `caches` which to do nothing to cloudflare adapter

### DIFF
--- a/.changeset/strong-worms-rest.md
+++ b/.changeset/strong-worms-rest.md
@@ -1,0 +1,5 @@
+---
+'@hono/vite-dev-server': patch
+---
+
+fix: add caches which to do nothing to cloudflare adapter

--- a/packages/dev-server/e2e/e2e.test.ts
+++ b/packages/dev-server/e2e/e2e.test.ts
@@ -151,3 +151,14 @@ test('Should set `workerd` as a runtime key', async ({ page }) => {
   expect(res?.ok()).toBe(true)
   expect(await res?.text()).toBe('workerd')
 })
+
+test('Should not throw an error if accessing the `caches`', async ({ page }) => {
+  const res = await page.goto('/cache')
+  expect(res?.ok()).toBe(true)
+  expect(await res?.text()).toBe('first')
+  const resCached = await page.goto('/cache')
+  expect(resCached?.ok()).toBe(true)
+  // Cache API provided by `getPlatformProxy` currently do nothing.
+  // It does **not** return cached content.
+  expect(await resCached?.text()).not.toBe('cached')
+})

--- a/packages/dev-server/e2e/mock/worker.ts
+++ b/packages/dev-server/e2e/mock/worker.ts
@@ -82,4 +82,21 @@ app.get('/env', (c) => {
 
 app.get('/runtime', (c) => c.text(getRuntimeKey()))
 
+app.get('/cache', async (c) => {
+  const myCache = await caches.open('myCache')
+  const res = await myCache.match(c.req.url)
+  if (res) {
+    return res
+  }
+  await myCache.put(
+    c.req.url,
+    new Response('cached', {
+      headers: {
+        'Cache-Control': 's-maxage=10',
+      },
+    })
+  )
+  return c.text('first')
+})
+
 export default app

--- a/packages/dev-server/e2e/wrangler.toml
+++ b/packages/dev-server/e2e/wrangler.toml
@@ -2,7 +2,7 @@
 VARIABLE_FROM_WRANGLER_TOML = "VARIABLE_FROM_WRANGLER_TOML_VALUE"
 
 [[d1_databases]]
-binding = "DB_FROM_WRANGLER_TOML" 
+binding = "DB_FROM_WRANGLER_TOML"
 database_name = "DB_NAME"
 database_id = "DB_ID"
 

--- a/packages/dev-server/src/adapter/cloudflare.ts
+++ b/packages/dev-server/src/adapter/cloudflare.ts
@@ -15,6 +15,8 @@ export const cloudflareAdapter: (options?: CloudflareAdapterOptions) => Promise<
   options
 ) => {
   proxy ??= await getPlatformProxy(options?.proxy)
+  // Cache API provided by `getPlatformProxy` currently do nothing.
+  Object.assign(globalThis, { caches: proxy.caches })
   return {
     env: proxy.env,
     executionContext: proxy.ctx,


### PR DESCRIPTION
Fixes #125 though currently `caches` does return a cached content.

See: https://developers.cloudflare.com/workers/wrangler/api/

> For the time being, all cache operations do nothing. A more accurate emulation will be made available soon.
