### PR TITLE
feat(cloudflare-pages): custom `_routes.json`

### DIFF
--- a/.changeset/moody-islands-wave.md
+++ b/.changeset/moody-islands-wave.md
@@ -1,0 +1,5 @@
+---
+"@hono/vite-cloudflare-pages": minor
+---
+
+feat: creating a `public/_routes.json` will override the automatic generation

--- a/packages/cloudflare-pages/README.md
+++ b/packages/cloudflare-pages/README.md
@@ -79,6 +79,8 @@ export const defaultOptions = {
 }
 ```
 
+This plugin generates `_routes.json` automatically. The automatic generation can be overridden by creating a `public/_routes.json`. See [Create a `_routes.json` file](https://developers.cloudflare.com/pages/functions/routing/#create-a-_routesjson-file) on Cloudflare Docs for more details.
+
 ## Build a client
 
 If you also want to build a client-side script, you can configure it as follows.

--- a/packages/cloudflare-pages/test/cloudflare-pages.test.ts
+++ b/packages/cloudflare-pages/test/cloudflare-pages.test.ts
@@ -87,6 +87,6 @@ describe('cloudflarePagesPlugin', () => {
     expect(output).toContain('Hello World')
 
     const routes = fs.readFileSync(routesFile, 'utf-8')
-    expect(routes).toContain('{"version":1,"include":["/"],"exclude":["Custom Routes"]}')
+    expect(routes).toContain('{"version":1,"include":["/"],"exclude":["/customRoute"]}')
   })
 })

--- a/packages/cloudflare-pages/test/cloudflare-pages.test.ts
+++ b/packages/cloudflare-pages/test/cloudflare-pages.test.ts
@@ -67,4 +67,26 @@ describe('cloudflarePagesPlugin', () => {
       '{"version":1,"include":["/*"],"exclude":["/favicon.ico","/static/*"]}'
     )
   })
+
+  it('Should not create a new _routes.json when _routes.json on output directory.', async () => {
+    const outputFile = `${testDir}/dist/_worker.js`
+    const routesFile = `${testDir}/dist/_routes.json`
+
+    expect(fs.existsSync(entryFile)).toBe(true)
+
+    await build({
+      publicDir: 'public-routes-json',
+      root: testDir,
+      plugins: [cloudflarePagesPlugin()],
+    })
+
+    expect(fs.existsSync(outputFile)).toBe(true)
+    expect(fs.existsSync(routesFile)).toBe(true)
+
+    const output = fs.readFileSync(outputFile, 'utf-8')
+    expect(output).toContain('Hello World')
+
+    const routes = fs.readFileSync(routesFile, 'utf-8')
+    expect(routes).toContain('{"version":1,"include":["/"],"exclude":["Custom Routes"]}')
+  })
 })

--- a/packages/cloudflare-pages/test/project/public-routes-json/_routes.json
+++ b/packages/cloudflare-pages/test/project/public-routes-json/_routes.json
@@ -1,0 +1,1 @@
+{"version":1,"include":["/"],"exclude":["Custom Routes"]}

--- a/packages/cloudflare-pages/test/project/public-routes-json/_routes.json
+++ b/packages/cloudflare-pages/test/project/public-routes-json/_routes.json
@@ -1,1 +1,1 @@
-{"version":1,"include":["/"],"exclude":["Custom Routes"]}
+{"version":1,"include":["/"],"exclude":["/customRoute"]}


### PR DESCRIPTION
Creating a `public/_routes.json` will override the automatic generation.
This is useful when we want to write include/exclude accurately.