### PR TITLE
fix(dev-server): use `ssrLoadModule` instead of Runtime API

### DIFF
--- a/.changeset/fair-chefs-sleep.md
+++ b/.changeset/fair-chefs-sleep.md
@@ -1,0 +1,5 @@
+---
+'@hono/vite-dev-server': patch
+---
+
+use `ssrLoadModule` instead of Runtime API

--- a/packages/dev-server/README.md
+++ b/packages/dev-server/README.md
@@ -8,7 +8,7 @@ You can develop your application with Vite. It's fast.
 - Support any `fetch`-based applications.
 - Hono applications run on.
 - Fast by Vite.
-- HMR
+- HMR (Only for the client side).
 - Plugins are available, e.g., Cloudflare Pages.
 - Also runs on Bun.
 

--- a/packages/dev-server/src/dev-server.ts
+++ b/packages/dev-server/src/dev-server.ts
@@ -72,7 +72,6 @@ export const defaultOptions: Required<Omit<DevServerOptions, 'env' | 'cf' | 'ada
 
 export function devServer(options?: DevServerOptions): VitePlugin {
   const entry = options?.entry ?? defaultOptions.entry
-  let runtime: ViteRuntime
   const plugin: VitePlugin = {
     name: '@hono/vite-dev-server',
     configureServer: async (server) => {
@@ -95,11 +94,10 @@ export function devServer(options?: DevServerOptions): VitePlugin {
               }
             }
           }
-          runtime ??= await createViteRuntime(server)
           let appModule
 
           try {
-            appModule = await runtime.executeEntrypoint(entry)
+            appModule = await server.ssrLoadModule(entry)
           } catch (e) {
             return next(e)
           }


### PR DESCRIPTION
With this PR, the dev server will use `server.ssrLoadModule` instead of the Runtime API introduced by #129.

The runtime API seems good. But after #129, the problem is that the dev server crashes if the Hono application has an error. Ref #132.

The best solution is to find a way to fix the issue while continuing to use Runtime API. However, I can't find a way, so I'll revert it. In the future, the Vite Enviroment API will be introduced and be stable, we can use it!

Fixes #132
Revert #129