### PR TITLE
feat(dev-server): transform HTML using Vite enabling HRM with official React plugin

### DIFF
--- a/packages/dev-server/src/dev-server.ts
+++ b/packages/dev-server/src/dev-server.ts
@@ -165,7 +165,7 @@ export function devServer(options?: DevServerOptions): VitePlugin {
                 response.headers.get('content-type')?.match(/^text\/html/)
               ) {
                 const script = '<script>import("/@vite/client")</script>'
-                return injectStringToResponse(response, script)
+                return transformHTML(injectStringToResponse(response, script), server, req.url)
               }
               return response
             },
@@ -276,4 +276,11 @@ function injectStringToResponse(response: Response, content: string) {
     headers,
     status: response.status,
   })
+}
+
+async function transformHTML (response: Response | null, viteServer: ViteDevServer, url: string)  {
+  if(!response) return null
+  const html = await response.text()
+  const htmlTransformed = await viteServer.transformIndexHtml(url, html)
+  return new Response(htmlTransformed, {headers: response.headers, status: response.status})
 }


### PR DESCRIPTION
vite react plugin add HMR support to vite. (Maybe other plugin do the same).

Today HMR is not working from component because Vite didn't transform the HTML.

This PR aim to fix this issue