### PR TITLE
docs(readme): Fix small typo in README code example

### DIFF
--- a/packages/dev-server/README.md
+++ b/packages/dev-server/README.md
@@ -147,7 +147,7 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   plugins: [
     devServer({
-      exclude: ['/assets/.*', ...defaultOptions.exclude],
+      exclude: ['/assets/*', ...defaultOptions.exclude],
     }),
   ],
 })


### PR DESCRIPTION
fix small typo in README, the problem was that glob in code example on line 150 was out of sync with the explanation of it on line 141