### PR TITLE
fix(dev-server): Move miniflare,wrangler to dev as it peer optional

### DIFF
--- a/.changeset/spotty-gifts-complain.md
+++ b/.changeset/spotty-gifts-complain.md
@@ -2,4 +2,4 @@
 '@hono/vite-dev-server': patch
 ---
 
-Remove miniflare from deps, and add it to peer optional, add initial bun & node adapter.
+Remove miniflare from deps, and add it to peer optional.

--- a/.changeset/spotty-gifts-complain.md
+++ b/.changeset/spotty-gifts-complain.md
@@ -1,0 +1,5 @@
+---
+'@hono/vite-dev-server': major
+---
+
+Remove miniflare from deps, and add it to peer optional, add initial bun & node adapter.

--- a/.changeset/spotty-gifts-complain.md
+++ b/.changeset/spotty-gifts-complain.md
@@ -1,5 +1,5 @@
 ---
-'@hono/vite-dev-server': major
+'@hono/vite-dev-server': patch
 ---
 
 Remove miniflare from deps, and add it to peer optional, add initial bun & node adapter.

--- a/packages/dev-server/README.md
+++ b/packages/dev-server/README.md
@@ -9,7 +9,8 @@ You can develop your application with Vite. It's fast.
 - Hono applications run on.
 - Fast by Vite.
 - HMR (Only for the client side).
-- Adapters are available, e.g., Cloudflare, Node.js, And Bun
+- Adapters are available, e.g., Cloudflare.
+- Also runs on Bun.
 
 ## Demo
 

--- a/packages/dev-server/README.md
+++ b/packages/dev-server/README.md
@@ -188,32 +188,6 @@ export default defineConfig(async () => {
 })
 ```
 
-### Node.js & Bun
-No additional dependencies needed.
-
-```ts
-import devServer from '@hono/vite-dev-server'
-import nodeAdapter from '@hono/vite-dev-server/node'
-// OR
-// import bunAdapter from '@hono/vite-dev-server/bun'
-import { defineConfig } from 'vite'
-
-export default defineConfig(async () => {
-  return {
-    plugins: [
-      devServer({
-        adapter: nodeAdapter,
-        // OR
-        // adapter: bunAdapter,
-      }),
-    ],
-  }
-})
-```
-
-Using selected adapter, In hono app you can access environtment variable like ```ctx.env``` or ```env(ctx)```.
-
-
 ## Client-side
 
 You can write client-side scripts and import them into your application using Vite's features.

--- a/packages/dev-server/README.md
+++ b/packages/dev-server/README.md
@@ -9,8 +9,7 @@ You can develop your application with Vite. It's fast.
 - Hono applications run on.
 - Fast by Vite.
 - HMR (Only for the client side).
-- Adapters are available, e.g., Cloudflare.
-- Also runs on Bun.
+- Adapters are available, e.g., Cloudflare, Node.js, And Bun
 
 ## Demo
 
@@ -167,6 +166,12 @@ You can pass the `env` value of a specified environment to the application.
 
 You can pass the Bindings specified in `wrangler.toml` to your application by using "Cloudflare Adapter".
 
+Install miniflare and wrangler to develop and deploy your cf project.
+
+```text
+npm i -D wrangler miniflare
+```
+
 ```ts
 import devServer from '@hono/vite-dev-server'
 import cloudflareAdapter from '@hono/vite-dev-server/cloudflare'
@@ -182,6 +187,32 @@ export default defineConfig(async () => {
   }
 })
 ```
+
+### Node.js & Bun
+No additional dependencies needed.
+
+```ts
+import devServer from '@hono/vite-dev-server'
+import nodeAdapter from '@hono/vite-dev-server/node'
+// OR
+// import bunAdapter from '@hono/vite-dev-server/bun'
+import { defineConfig } from 'vite'
+
+export default defineConfig(async () => {
+  return {
+    plugins: [
+      devServer({
+        adapter: nodeAdapter,
+        // OR
+        // adapter: bunAdapter,
+      }),
+    ],
+  }
+})
+```
+
+Using selected adapter, In hono app you can access environtment variable like ```ctx.env``` or ```env(ctx)```.
+
 
 ## Client-side
 

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -60,6 +60,7 @@
     "@playwright/test": "^1.37.1",
     "glob": "^10.3.10",
     "hono": "^4.4.11",
+    "miniflare": "^3.20240701.0",
     "playwright": "^1.39.0",
     "publint": "^0.2.5",
     "rimraf": "^5.0.1",
@@ -69,14 +70,26 @@
     "wrangler": "^3.63.1"
   },
   "peerDependencies": {
-    "hono": "*"
+    "hono": "*",
+    "miniflare": "*",
+    "wrangler": "*"
+  },
+  "peerDependenciesMeta": {
+    "hono": {
+      "optional": false
+    },
+    "miniflare": {
+      "optional": true
+    },
+    "wrangler": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=18.14.1"
   },
   "dependencies": {
     "@hono/node-server": "^1.12.0",
-    "miniflare": "^3.20240701.0",
     "minimatch": "^9.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -942,6 +942,15 @@ __metadata:
     wrangler: ^3.63.1
   peerDependencies:
     hono: "*"
+    miniflare: "*"
+    wrangler: "*"
+  peerDependenciesMeta:
+    hono:
+      optional: false
+    miniflare:
+      optional: true
+    wrangler:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Since dev-server is not required to use cloudflare adapter,
as it so i try to move miniflare dependencies into devDependencies and add them into optional peerDependencies including wrangler.