### PR TITLE
fix(dev-server) Missing exports for node,bun adapter

### DIFF
--- a/.changeset/wild-countries-tan.md
+++ b/.changeset/wild-countries-tan.md
@@ -1,0 +1,5 @@
+---
+'@hono/vite-dev-server': minor
+---
+
+(fix) missing export for initial node, bun adapter in the package.json from the previous version

--- a/.changeset/wild-countries-tan.md
+++ b/.changeset/wild-countries-tan.md
@@ -1,5 +1,5 @@
 ---
-'@hono/vite-dev-server': minor
+'@hono/vite-dev-server': patch
 ---
 
 (fix) missing export for initial node, bun adapter in the package.json from the previous version

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -33,6 +33,16 @@
       "types": "./dist/adapter/cloudflare.d.ts",
       "require": "./dist/adapter/cloudflare.cjs",
       "import": "./dist/adapter/cloudflare.js"
+    },
+    "./node": {
+      "types": "./dist/adapter/node.d.ts",
+      "require": "./dist/adapter/node.cjs",
+      "import": "./dist/adapter/node.js"
+    },
+    "./bun": {
+      "types": "./dist/adapter/bun.d.ts",
+      "require": "./dist/adapter/bun.cjs",
+      "import": "./dist/adapter/bun.js"
     }
   },
   "typesVersions": {
@@ -42,6 +52,12 @@
       ],
       "cloudflare": [
         "./dist/adapter/cloudflare.d.ts"
+      ],
+      "node": [
+        "./dist/adapter/node.d.ts"
+      ],
+      "bun": [
+        "./dist/adapter/bun.d.ts"
       ]
     }
   },


### PR DESCRIPTION
Fix missing export in package.json

In the recent update i have add very initial bun and node.js adapter but i forget to add exports definition in the package.json so the update does not export module correctly.

https://github.com/honojs/vite-plugins/pull/166
https://github.com/honojs/vite-plugins/pull/167