### PR TITLE
feat(build): add Deno adapter

### DIFF
--- a/.changeset/strong-pianos-divide.md
+++ b/.changeset/strong-pianos-divide.md
@@ -1,0 +1,5 @@
+---
+'@hono/vite-build': minor
+---
+
+Added Deno adapter

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -33,7 +33,7 @@
       "import": "./dist/adapter/cloudflare-pages/index.js"
     },
     "./cloudflare-workers": {
-      "types": "./dist/adapter/cloudflate-workers/index.d.ts",
+      "types": "./dist/adapter/cloudflare-workers/index.d.ts",
       "import": "./dist/adapter/cloudflare-workers/index.js"
     },
     "./deno": {

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -33,6 +33,10 @@
       "import": "./dist/adapter/cloudflare-pages/index.js"
     },
     "./cloudflare-workers": {
+      "types": "./dist/adapter/cloudflate-workers/index.d.ts",
+      "import": "./dist/adapter/cloudflare-workers/index.js"
+    },
+    "./deno": {
       "types": "./dist/adapter/deno/index.d.ts",
       "import": "./dist/adapter/deno/index.js"
     }

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -33,8 +33,8 @@
       "import": "./dist/adapter/cloudflare-pages/index.js"
     },
     "./cloudflare-workers": {
-      "types": "./dist/adapter/cloudflare-workers/index.d.ts",
-      "import": "./dist/adapter/cloudflare-workers/index.js"
+      "types": "./dist/adapter/deno/index.d.ts",
+      "import": "./dist/adapter/deno/index.js"
     }
   },
   "typesVersions": {

--- a/packages/build/src/adapter/deno/index.ts
+++ b/packages/build/src/adapter/deno/index.ts
@@ -1,0 +1,37 @@
+import type { Plugin } from 'vite'
+import type { BuildOptions } from '../../base.js'
+import buildPlugin from '../../base.js'
+import { serveStaticHook } from '../../entry/serve-static.js'
+
+export type DenoBuildOptions = {
+  staticRoot?: string | undefined
+} & BuildOptions
+
+const denoBuildPlugin = (pluginOptions?: DenoBuildOptions): Plugin => {
+  return {
+    ...buildPlugin({
+      ...{
+        entryContentBeforeHooks: [
+          async (appName, options) => {
+            // eslint-disable-next-line quotes
+            let code = "import { serveStatic } from 'hono/deno'\n"
+            code += serveStaticHook(appName, {
+              filePaths: options?.staticPaths,
+              root: pluginOptions?.staticRoot,
+            })
+            return code
+          },
+        ],
+        entryContentAfterHooks: [
+          async (appName) => {
+            return `Deno.serve(${appName}.fetch)`
+          },
+        ],
+      },
+      ...pluginOptions,
+    }),
+    name: '@hono/vite-build/deno',
+  }
+}
+
+export default denoBuildPlugin

--- a/packages/build/src/adapter/deno/index.ts
+++ b/packages/build/src/adapter/deno/index.ts
@@ -22,11 +22,6 @@ const denoBuildPlugin = (pluginOptions?: DenoBuildOptions): Plugin => {
             return code
           },
         ],
-        entryContentAfterHooks: [
-          async (appName) => {
-            return `Deno.serve(${appName}.fetch)`
-          },
-        ],
       },
       ...pluginOptions,
     }),

--- a/packages/build/test/deno.test.ts
+++ b/packages/build/test/deno.test.ts
@@ -1,0 +1,39 @@
+import { build } from 'vite'
+import { existsSync, readFileSync, rmSync } from 'node:fs'
+import denoBuildPlugin from '../src/adapter/deno'
+
+describe('Build Plugin with Deno Adapter', () => {
+  const testDir = './test/mocks/app-static-files'
+  const entry = './src/server.ts'
+
+  afterAll(() => {
+    rmSync(`${testDir}/dist`, { recursive: true, force: true })
+  })
+
+  it('Should build the project correctly with the plugin', async () => {
+    const outputFile = `${testDir}/dist/index.js`
+
+    await build({
+      root: testDir,
+      plugins: [
+        denoBuildPlugin({
+          entry,
+        }),
+      ],
+    })
+
+    expect(existsSync(outputFile)).toBe(true)
+
+    const output = readFileSync(outputFile, 'utf-8')
+    expect(output).toContain('Hello World')
+    expect(output).toContain('use("/foo.txt"')
+    expect(output).toContain('use("/js/*"')
+
+    const outputFooTxt = readFileSync(`${testDir}/dist/foo.txt`, 'utf-8')
+    expect(outputFooTxt).toContain('foo')
+
+    const outputJsClientJs = readFileSync(`${testDir}/dist/js/client.js`, 'utf-8')
+    // eslint-disable-next-line quotes
+    expect(outputJsClientJs).toContain("console.log('foo')")
+  })
+})


### PR DESCRIPTION
I added adapter for `Deno` for build plugin.
It uses `Deno.serve`.
```ts
import denoBuildPlugin from '@hono/vite-build/deno'
```