### PR TITLE
docs(build): added example project link

### DIFF
--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -212,6 +212,10 @@ app.get('/', (c) => {
 })
 ```
 
+## Example
+
+You can see the example project here - [hono-vite-jsx](https://github.com/honojs/examples/tree/main/hono-vite-jsx)
+
 ## Authors
 
 - Yusuke Wada <https://github.com/yusukebe>


### PR DESCRIPTION
- [x] Added link for [hono-vite-jsx](https://github.com/honojs/examples/tree/main/hono-vite-jsx), as it uses `@hono/vite-build`