### PR TITLE
[ssg] Preserve the SSR server instance during page rendering

### DIFF
--- a/.changeset/curly-cherries-tell.md
+++ b/.changeset/curly-cherries-tell.md
@@ -1,0 +1,5 @@
+---
+'@hono/vite-ssg': patch
+---
+
+Preserve the SSR server instance during page rendering

--- a/packages/ssg/src/ssg.ts
+++ b/packages/ssg/src/ssg.ts
@@ -56,7 +56,6 @@ export const ssgBuild = (options?: SSGOptions): Plugin => {
         build: { ssr: true },
       })
       const module = await server.ssrLoadModule(entry)
-      server.close()
 
       const app = module['default'] as Hono
 
@@ -83,6 +82,8 @@ export const ssgBuild = (options?: SSGOptions): Plugin => {
         },
         { dir: outDir }
       )
+
+      server.close()
 
       if (!result.success) {
         throw result.error

--- a/packages/ssg/test/app.ts
+++ b/packages/ssg/test/app.ts
@@ -6,4 +6,10 @@ app.get('/', (c) => {
   return c.html('<html><body><h1>Hello!</h1></body></html>')
 })
 
+app.get('/dynamic-import', async (c) => {
+  // @ts-expect-error
+  const module = await import('./sample.js')
+  return c.text('Dynamic import works: ' + module.default)
+})
+
 export default app

--- a/packages/ssg/test/sample.js
+++ b/packages/ssg/test/sample.js
@@ -1,0 +1,1 @@
+export default "sample!";

--- a/packages/ssg/test/ssg.test.ts
+++ b/packages/ssg/test/ssg.test.ts
@@ -9,6 +9,7 @@ describe('ssgPlugin', () => {
   const entryFile = './test/app.ts'
   const outDir = path.resolve(testDir, 'dist')
   const outputFile = path.resolve(outDir, 'index.html')
+  const outputFileWithDynamicImport = path.resolve(outDir, 'dynamic-import.txt')
 
   beforeAll(() => {
     fs.mkdirSync(testDir, { recursive: true })
@@ -37,6 +38,11 @@ describe('ssgPlugin', () => {
 
     const output = fs.readFileSync(outputFile, 'utf-8')
     expect(output).toBe('<html><body><h1>Hello!</h1></body></html>')
+
+    expect(fs.existsSync(outputFileWithDynamicImport)).toBe(true)
+
+    const outputDynamicImport = fs.readFileSync(outputFileWithDynamicImport, 'utf-8')
+    expect(outputDynamicImport).toBe('Dynamic import works: sample!')
 
     // Should not output files corresponding to a virtual entry
     expect(fs.existsSync(path.resolve(outDir, 'assets'))).toBe(false)


### PR DESCRIPTION
When using `@hono/vite-ssg` with Vite v6, if the page has dynamic import, the SSR server is closed when resolving the dynamic import and an error occurs.

A reproduction repository can be found at https://github.com/berlysia/sandbox-hono-ssg-vite-v6-dynamic-import.

As a workaround, simply maintain the SSR server until `toSSG` is done.