### PR TITLE
fix(dev-server): Fix issue in dev-server where requestListener would return null

### DIFF
--- a/.changeset/long-panthers-decide.md
+++ b/.changeset/long-panthers-decide.md
@@ -1,0 +1,5 @@
+---
+'@hono/vite-dev-server': patch
+---
+
+dev-server plugin getRequestListener fetchCallback now always returns Promise<Response> instead of sometimes returning Promise<null>

--- a/packages/dev-server/e2e/e2e.test.ts
+++ b/packages/dev-server/e2e/e2e.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, request } from '@playwright/test'
 
 test('Should return 200 response', async ({ page }) => {
   const response = await page.goto('/')
@@ -121,4 +121,17 @@ test('Should set `cf` properties', async ({ page }) => {
 test('Should return files in the public directory', async ({ page }) => {
   const res = await page.goto('/hono-logo.png')
   expect(res?.status()).toBe(200)
+})
+
+test('Should not crash when receiving a HEAD request', async () => {
+  const apiContext = await request.newContext()
+  const response = await apiContext.fetch('/', {
+    method: 'HEAD',
+  })
+
+  expect(response.status()).toBe(200)
+  expect(response.headers()['content-type']).toMatch(/^text\/html/)
+  const body = await response.body()
+  expect(body.length).toBe(0)
+  await apiContext.dispose()
 })

--- a/packages/dev-server/src/dev-server.ts
+++ b/packages/dev-server/src/dev-server.ts
@@ -126,7 +126,7 @@ export function devServer(options?: DevServerOptions): VitePlugin {
           }
 
           getRequestListener(
-            async (request) => {
+            async (request): Promise<Response> => {
               let env: Env = {}
 
               if (options?.env) {
@@ -168,7 +168,7 @@ export function devServer(options?: DevServerOptions): VitePlugin {
                   .get('content-security-policy')
                   ?.match(/'nonce-([^']+)'/)?.[1]
                 const script = `<script${nonce ? ` nonce="${nonce}"` : ''}>import("/@vite/client")</script>`
-                return injectStringToResponse(response, script)
+                return injectStringToResponse(response, script) ?? response
               }
               return response
             },


### PR DESCRIPTION
I was running into an error using honox, this vite dev server plugin, and hono node-server.

The error stack in prod is like
```
file:///app/node_modules/@hono/node-server/dist/index.mjs:345
   if (cacheKey in res) {
                ^
 
 TypeError: Cannot use 'in' operator to search for 'Symbol(cache)' in null
     at responseViaResponseObject (file:///app/node_modules/@hono/node-server/dist/index.mjs:345:16)
     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
 
 Node.js v23.3.0
```

I believe that comes from the `cacheKey in res` here https://github.com/honojs/node-server/blob/590fe6cef8a795ea10c300033387f13ed31e144f/src/listener.ts#L86

But that is downstream from calling requestListener to get a Promise<Response>.

Before this change, if the response from the router has `reuest.body === null` (e.g. a Response with status 404 and no response body), then the dev-server will return null [here](https://github.com/honojs/vite-plugins/blob/main/packages/dev-server/src/dev-server.ts#L233), not a response, and downstream things that expect a response (like node-server) will error.

This change makes it so if the dev server is unable to inject script into response to build a new response (e.g. when there is no response.body at all), a response is still returned.