### PR TITLE
feat: add transformEntry option

### DIFF
--- a/packages/build/src/base.ts
+++ b/packages/build/src/base.ts
@@ -10,6 +10,7 @@ export type BuildOptions = {
    * @default ['src/index.ts', './src/index.tsx', './app/server.ts']
    */
   entry?: string | string[]
+  transformEntry?: ((code: string, id: string) => string) | undefined
   /**
    * @default './dist'
    */
@@ -27,7 +28,7 @@ export type BuildOptions = {
 export const defaultOptions: Required<
   Omit<
     BuildOptions,
-    'entryContentAfterHooks' | 'entryContentBeforeHooks' | 'entryContentDefaultExportHook'
+    'entryContentAfterHooks' | 'entryContentBeforeHooks' | 'entryContentDefaultExportHook' | 'transformEntry'
   >
 > = {
   entry: ['src/index.ts', './src/index.tsx', './app/server.ts'],
@@ -99,6 +100,23 @@ const buildPlugin = (options: BuildOptions): Plugin => {
           entryContentDefaultExportHook: options.entryContentDefaultExportHook,
           staticPaths,
         })
+      }
+    },
+    transform(code, id) {
+      const entry = options.entry ?? defaultOptions.entry
+
+      if (typeof entry === 'string') {
+        if (!id.endsWith(entry)) {
+          return
+        }
+      } else {
+        if (!entry.includes(id)) {
+          return
+        }
+      }
+
+      if (options.transformEntry !== undefined) {
+        return options.transformEntry(code, id)
       }
     },
     apply: options?.apply ?? defaultOptions.apply,


### PR DESCRIPTION
This way, I can "inject" a SSR Vue app.

The implementation, runs the same `transformEntry` for every entry. Maybe move the entry check from the transform?

Example:

```ts
    build({
      entry: 'src/index.ts',
      transformEntry: (code) => {
        const template = readFileSync(join(process.cwd(), 'dist', 'index.html'), 'utf-8')

        const mod = parseModule(`import { render } from './app/entry-server'
${code}
let template = \`${template}\`
app.get('*', async (c) => {
const { html, payload } = await render()
template = template.replace('<!--app-html-->', html)
template = template.replace('<!--payload-->', '<script>window.__payload = ' + JSON.stringify(payload ?? {}) + '</script>')
return c.html(template)
})

export default app`)

        return mod.generate()
      },
      minify: false,
      external: [
        'vue',
        'hono',
        'pinia',
        '@pinia/colada',
      ],
      staticPaths: ['./assets']
    }),
```