### PR TITLE
Fixed problem with source map not working when reading entry files

### DIFF
--- a/.changeset/green-bulldogs-itch.md
+++ b/.changeset/green-bulldogs-itch.md
@@ -1,0 +1,5 @@
+---
+'@hono/vite-dev-server': patch
+---
+
+fix: Fixed problem with source map not working when reading entry files

--- a/packages/dev-server/src/dev-server.ts
+++ b/packages/dev-server/src/dev-server.ts
@@ -107,7 +107,15 @@ export function devServer(options?: DevServerOptions): VitePlugin {
             loadModule = options.loadModule
           } else {
             loadModule = async (server, entry) => {
-              const appModule = await server.ssrLoadModule(entry)
+              let appModule
+              try {
+                appModule = await server.ssrLoadModule(entry)
+              } catch (e) {
+                if (e instanceof Error) {
+                  server.ssrFixStacktrace(e)
+                }
+                throw e
+              }
               const exportName = options?.export ?? defaultOptions.export
               const app = appModule[exportName] as { fetch: Fetch }
               if (!app) {


### PR DESCRIPTION
Fixed problem with source map not working when reading entry files.

fix #227 