### PR TITLE
fix(ssg): inherit mode to load .env.{mode}

### DIFF
--- a/.changeset/proud-rats-flow.md
+++ b/.changeset/proud-rats-flow.md
@@ -1,0 +1,5 @@
+---
+'@hono/vite-ssg': patch
+---
+
+Load .env.{mode} to bundle environment variable

--- a/packages/ssg/src/ssg.ts
+++ b/packages/ssg/src/ssg.ts
@@ -54,6 +54,7 @@ export const ssgBuild = (options?: SSGOptions): Plugin => {
       const server = await createServer({
         plugins: [],
         build: { ssr: true },
+        mode: config.mode,
       })
       const module = await server.ssrLoadModule(entry)
 


### PR DESCRIPTION
`@hono/vite-ssg` doesn't inherit mode now.
So, it cannot load [`.env.{mode}`](https://vite.dev/guide/env-and-mode.html#env-files) file.
repro: https://stackblitz.com/edit/hono-vite-ssg-mode?file=readme.md


