### PR TITLE
feat(build): support non-fetch handlers for Cloudflare Workers

### DIFF
--- a/.changeset/selfish-panthers-speak.md
+++ b/.changeset/selfish-panthers-speak.md
@@ -1,0 +1,5 @@
+---
+"@hono/vite-build": patch
+---
+
+feat(build): support non-fetch handlers for Cloudflare Workers

--- a/packages/build/src/adapter/cloudflare-workers/index.ts
+++ b/packages/build/src/adapter/cloudflare-workers/index.ts
@@ -7,6 +7,25 @@ export type CloudflareWorkersBuildOptions = BuildOptions
 const cloudflareWorkersBuildPlugin = (pluginOptions?: CloudflareWorkersBuildOptions): Plugin => {
   return {
     ...buildPlugin({
+      entryContentAfterHooks: [
+        () => `
+        const merged = {}
+        const definedHandlers = new Set()
+        for (const [file, app] of Object.entries(modules)) {
+          for (const [key, handler] of Object.entries(app)) {
+            if (key !== 'fetch') {
+              if (definedHandlers.has(key)) {
+                throw new Error(\`Handler "\${key}" is defined in multiple entry files. Please ensure each handler (except fetch) is defined only once.\`);
+              }
+              definedHandlers.add(key)
+              merged[key] = handler
+            }
+          }
+        }
+      `,
+      ],
+      entryContentDefaultExportHook: (appName) =>
+        `export default { ...merged, fetch: ${appName}.fetch }`,
       ...pluginOptions,
     }),
     name: '@hono/vite-build/cloudflare-workers',

--- a/packages/build/test/adapter.test.ts
+++ b/packages/build/test/adapter.test.ts
@@ -166,7 +166,7 @@ describe('Build Plugin with Cloudflare Pages Adapter', () => {
   })
 })
 
-describe('Build Plugin with Cloudflare Workers Adapter', () => {
+describe('Build Plugin with Cloudflare Workers Adapter with single entry file', () => {
   const testDir = './test/mocks/app-static-files'
   const outputFile = `${testDir}/dist/index.js`
 
@@ -196,6 +196,36 @@ describe('Build Plugin with Cloudflare Workers Adapter', () => {
 
     const result = app.scheduled()
     expect(result).toBe('Hello World')
+  })
+})
+
+describe('Build Plugin with Cloudflare Workers Adapter with multiple entry files', () => {
+  const testDir = './test/mocks/app-static-files'
+  const outputFile = 'index-multiple.js'
+  const outputPath = `${testDir}/dist/${outputFile}`
+
+  afterAll(() => {
+    rmSync(`${testDir}/dist`, { recursive: true, force: true })
+  })
+
+  it('Should build the project correctly with the plugin', async () => {
+    await build({
+      root: testDir,
+      plugins: [
+        cloudflareWorkersPlugin({
+          entry: ['./src/server-fetch-with-handlers.ts', './src/server-fetch-with-handlers2.ts'],
+          output: outputFile,
+        }),
+      ],
+    })
+    expect(existsSync(outputPath)).toBe(true)
+
+    const output = readFileSync(outputPath, 'utf-8')
+    expect(output).toContain('Hello World')
+  })
+
+  it('Should cause a runtime error when the same handler is registered more than once', async () => {
+    expect(import(outputPath)).rejects.toThrow(/scheduled/)
   })
 })
 

--- a/packages/build/test/adapter.test.ts
+++ b/packages/build/test/adapter.test.ts
@@ -2,6 +2,7 @@ import { build } from 'vite'
 import { existsSync, readFileSync, rmSync } from 'node:fs'
 import bunBuildPlugin from '../src/adapter/bun'
 import cloudflarePagesPlugin from '../src/adapter/cloudflare-pages'
+import cloudflareWorkersPlugin from '../src/adapter/cloudflare-workers'
 import denoBuildPlugin from '../src/adapter/deno'
 import netlifyFunctionsPlugin from '../src/adapter/netlify-functions'
 import nodeBuildPlugin from '../src/adapter/node'
@@ -162,6 +163,39 @@ describe('Build Plugin with Cloudflare Pages Adapter', () => {
 
     const routes = readFileSync(routesFile, 'utf-8')
     expect(routes).toContain('{"version":1,"include":["/"],"exclude":["/customRoute"]}')
+  })
+})
+
+describe('Build Plugin with Cloudflare Workers Adapter', () => {
+  const testDir = './test/mocks/app-static-files'
+  const outputFile = `${testDir}/dist/index.js`
+
+  afterAll(() => {
+    rmSync(`${testDir}/dist`, { recursive: true, force: true })
+  })
+
+  it('Should build the project correctly with the plugin', async () => {
+    await build({
+      root: testDir,
+      plugins: [
+        cloudflareWorkersPlugin({
+          entry: './src/server-fetch-with-handlers.ts',
+        }),
+      ],
+    })
+
+    expect(existsSync(outputFile)).toBe(true)
+
+    const output = readFileSync(outputFile, 'utf-8')
+    expect(output).toContain('Hello World')
+  })
+
+  it('Should return correct result from the scheduled handler in the output file', async () => {
+    const module = await import(outputFile)
+    const app = module.default
+
+    const result = app.scheduled()
+    expect(result).toBe('Hello World')
   })
 })
 

--- a/packages/build/test/mocks/app-static-files/src/server-fetch-with-handlers.ts
+++ b/packages/build/test/mocks/app-static-files/src/server-fetch-with-handlers.ts
@@ -1,0 +1,8 @@
+import app from './server'
+
+export default {
+  fetch: app.fetch,
+  scheduled: function () {
+    return 'Hello World'
+  },
+}

--- a/packages/build/test/mocks/app-static-files/src/server-fetch-with-handlers2.ts
+++ b/packages/build/test/mocks/app-static-files/src/server-fetch-with-handlers2.ts
@@ -1,0 +1,8 @@
+import app from './server'
+
+export default {
+  fetch: app.fetch,
+  scheduled: function () {
+    return 'Hello World 2'
+  },
+}


### PR DESCRIPTION
Closes #214

This PR enhances the `@hono/vite-build/cloudflare-workers` adapter to support exporting other Cloudflare Workers event handlers (like `scheduled`, `queue`, etc.) alongside the primary `fetch` handler. This enables the use of features such as Scheduled Events and Queue Consumers with Hono applications built using this plugin.

## How it works

The adapter now uses Vite plugin hooks (`entryContentAfterHooks` and `entryContentDefaultExportHook`) to inspect the default export(s) from the specified entry file(s). It collects any non-fetch handlers found and merges them into the final worker export object.

**Important:** If the same non-fetch handler (e.g., `scheduled`) is defined in multiple entry files specified in the `entry` option, an error will be thrown to prevent ambiguity and ensure predictable behavior.

## Example Usage

```ts
// vite.config.ts
import build from '@hono/vite-build/cloudflare-workers'
import { defineConfig } from 'vite'

export default defineConfig({
  plugins: [build()]
})

// src/worker.ts
import { Hono } from 'hono'

const app = new Hono()

app.get('/', (c) => c.text('Hello Hono!'))

export default {
  fetch: app.fetch,
  async scheduled(event, env, ctx) {
    console.log(`Scheduled event triggered at: ${new Date(event.scheduledTime)}`)
    // Add your scheduled logic here
  },
  // Add other handlers like queue, email, etc. if needed
  // async queue(batch, env, ctx) { ... }
}
```