### PR TITLE
feat(dev-server): add `x-skip-hono-dev-server` header

### DIFF
--- a/packages/dev-server/src/dev-server.ts
+++ b/packages/dev-server/src/dev-server.ts
@@ -87,6 +87,9 @@ export function devServer(options?: DevServerOptions): VitePlugin {
           res: http.ServerResponse,
           next: Connect.NextFunction
         ): Promise<void> {
+          if (req.headers['x-skip-hono-dev-server']) {
+            return next();
+          }
           if (req.url) {
             const filePath = path.join(publicDirPath, req.url)
             try {


### PR DESCRIPTION
This PR adds the ability to set an  `x-skip-hono-dev-server` to any request, which will skip hono's middleware and pass the request directly further down to Vite's dev server. 

This basically does the same as the `exclude` option, but on a per request basis. 

---

**Why do I need this?**
Well that is a warranted question 😅 I'm was trying around with the CF adapter and wanted to provide a `ASSETS` binding ([see CF docs here](https://developers.cloudflare.com/workers/static-assets/binding/#runtime-api-reference)) and had the issue that it was not easy to just load the underlying resource. With this PR roughly something like this is possible:

```ts
devServer({
  entry: './src/functions/main.ts',
  adapter: cloudflareAdapter,
  exclude: [],
  env: async () => ({
    ASSETS: {
      fetch(input: Request | string | URL, init?: RequestInit): Promise<Response> {
        return fetch(
          input,
          { ...init, headers: { ...init?.headers, '`x-skip-hono-dev-server': 'true' } }
        );
      }
    }
  })
})
```

> [!NOTE]
> This code does not cover all edge cases, which can happen for `ASSETS` bindings. But with this PR it is even possible to implement it.