### PR TITLE
add aws lambda support

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -47,6 +47,10 @@
     "./vercel": {
       "types": "./dist/adapter/vercel/index.d.ts",
       "import": "./dist/adapter/vercel/index.js"
+    },
+    "./aws-lambda": {
+      "types": "./dist/adapter/aws-lambda/index.d.ts",
+      "import": "./dist/adapter/aws-lambda/index.js"
     }
   },
   "typesVersions": {
@@ -74,6 +78,9 @@
       ],
       "vercel": [
         "./dist/adapter/vercel/index.d.ts"
+      ],
+      "aws-lambda": [
+        "./dist/adapter/aws-lambda/index.d.ts"
       ]
     }
   },

--- a/packages/build/src/adapter/aws-lambda/index.ts
+++ b/packages/build/src/adapter/aws-lambda/index.ts
@@ -1,0 +1,41 @@
+import type { Plugin } from 'vite'
+import type { BuildOptions } from '../../base.js'
+import buildPlugin from '../../base.js'
+import { serveStaticHook } from '../../entry/serve-static.js'
+
+export type AwsLambdaBuildOptions = {
+  staticRoot?: string | undefined
+} & BuildOptions
+
+const awsLambdaBuildPlugin = (pluginOptions?: AwsLambdaBuildOptions): Plugin => {
+  return {
+    ...buildPlugin({
+      entryContentBeforeHooks: [
+        async (appName, options) => {
+          // eslint-disable-next-line quotes
+          let code = "import { serveStatic } from '@hono/node-server/serve-static'\n"
+          code += serveStaticHook(appName, {
+            filePaths: options?.staticPaths,
+            root: pluginOptions?.staticRoot,
+          })
+          return code
+        },
+      ],
+      entryContentAfterHooks: [
+        async (appName) => {
+          // eslint-disable-next-line quotes
+          let code = "import { handle } from 'hono/aws-lambda'\n"
+          code += `export const handler = handle(${appName})\n`
+          return code
+        },
+      ],
+      // To avoid `Runtime.UserCodeSyntaxError: SyntaxError: Cannot use import statement outside a module`,
+      // the output file is specified as .mjs.
+      output: 'index.mjs',
+      ...pluginOptions,
+    }),
+    name: '@hono/vite-build/aws-lambda',
+  }
+}
+
+export default awsLambdaBuildPlugin


### PR DESCRIPTION
This pull request adds support for deploying to AWS Lambda in `@hono/vite-build` . This allows Hono applications to be easily run in an AWS Lambda environment.

* Added an adapter for AWS Lambda ( `@hono/vite-build/aws-lambda` ).

You can verify that an application built using create-hono-app is working at the following URL:
[Examples x-basic template running on AWS Lambda Function URL](https://oqukf3g4uas5cz3qjutwblp2ly0goppx.lambda-url.ap-northeast-1.on.aws/)

----

By the way, in the `public/.assetsignore` file of the `x-basic` template, `.vite/` is listed. However, the output `dist/index.js` includes `Oe.use("/.assetsignore",gt({root:"./"}));Oe.use("/favicon.ico",gt({root:"./"}));Oe.use("/.vite/*",gt({root:"./"}));Oe.use("/static/*",gt({root:"./"}));` . This seems to be the build result of serveStatic. Is it okay that `.vite/` is included here and not ignored in the code?