### PR TITLE
feat(ssg): add support for ssg plugins

### DIFF
--- a/.changeset/angry-ladybugs-repair.md
+++ b/.changeset/angry-ladybugs-repair.md
@@ -1,0 +1,5 @@
+---
+'@hono/vite-ssg': minor
+---
+
+feat: add support for ssg plugins

--- a/packages/ssg/README.md
+++ b/packages/ssg/README.md
@@ -60,6 +60,12 @@ The options are below.
 ```ts
 type SSGOptions = {
   entry?: string
+  /**
+   * Hono SSG plugins to use.
+   * These are not Vite plugins, but plugins for Hono's static site generation.
+   * @see https://hono.dev/docs/helpers/ssg#plugins
+   */
+  plugins?: SSGPlugin[]
 }
 ```
 
@@ -68,6 +74,7 @@ Default values:
 ```ts
 const defaultOptions = {
   entry: './src/index.tsx',
+  plugins: [],
 }
 ```
 

--- a/packages/ssg/package.json
+++ b/packages/ssg/package.json
@@ -41,7 +41,7 @@
   "homepage": "https://github.com/honojs/vite-plugins",
   "devDependencies": {
     "glob": "^10.3.10",
-    "hono": "^4.2.7",
+    "hono": "^4.9.0",
     "publint": "^0.1.12",
     "rimraf": "^5.0.1",
     "tsup": "^7.2.0",

--- a/packages/ssg/package.json
+++ b/packages/ssg/package.json
@@ -49,7 +49,7 @@
     "vitest": "^1.2.1"
   },
   "peerDependencies": {
-    "hono": ">=4.0.0"
+    "hono": ">=4.8.0"
   },
   "engines": {
     "node": ">=18.14.1"

--- a/packages/ssg/src/ssg.ts
+++ b/packages/ssg/src/ssg.ts
@@ -1,15 +1,18 @@
 import type { Hono } from 'hono'
 import { toSSG } from 'hono/ssg'
+import type { SSGPlugin } from 'hono/ssg'
 import type { Plugin, ResolvedConfig } from 'vite'
 import { createServer } from 'vite'
 import { relative } from 'node:path'
 
 type SSGOptions = {
   entry?: string
+  plugins?: SSGPlugin[]
 }
 
 export const defaultOptions: Required<SSGOptions> = {
   entry: './src/index.tsx',
+  plugins: [],
 }
 
 export const ssgBuild = (options?: SSGOptions): Plugin => {
@@ -81,7 +84,7 @@ export const ssgBuild = (options?: SSGOptions): Plugin => {
             return
           },
         },
-        { dir: outDir }
+        { dir: outDir, plugins: options?.plugins ?? defaultOptions.plugins }
       )
 
       server.close()

--- a/packages/ssg/src/ssg.ts
+++ b/packages/ssg/src/ssg.ts
@@ -7,6 +7,11 @@ import { relative } from 'node:path'
 
 type SSGOptions = {
   entry?: string
+  /**
+   * Hono SSG plugins to use.
+   * These are not Vite plugins, but plugins for Hono's static site generation.
+   * @see https://hono.dev/docs/helpers/ssg#plugins
+   */
   plugins?: SSGPlugin[]
 }
 

--- a/packages/ssg/test/ssg.test.ts
+++ b/packages/ssg/test/ssg.test.ts
@@ -1,3 +1,4 @@
+import type { SSGPlugin } from 'hono/ssg'
 import { build } from 'vite'
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import fs from 'node:fs'
@@ -79,5 +80,42 @@ describe('ssgPlugin', () => {
 
     const entryOutput = fs.readFileSync(entryOutputFile, 'utf-8')
     expect(entryOutput.length).toBeGreaterThan(0)
+  })
+
+  it('Should apply ssg plugins', async () => {
+    let beforeRequestCalled = false
+    let afterResponseCalled = false
+    let afterGenerateCalled = false
+
+    const testPlugin: SSGPlugin = {
+      beforeRequestHook: (req) => {
+        beforeRequestCalled = true
+        return req
+      },
+      afterResponseHook: (res) => {
+        afterResponseCalled = true
+        return res
+      },
+      afterGenerateHook: () => {
+        afterGenerateCalled = true
+      },
+    }
+
+    await build({
+      plugins: [
+        ssgPlugin({
+          entry: entryFile,
+          plugins: [testPlugin],
+        }),
+      ],
+      build: {
+        outDir,
+        emptyOutDir: true,
+      },
+    })
+
+    expect(beforeRequestCalled).toBe(true)
+    expect(afterResponseCalled).toBe(true)
+    expect(afterGenerateCalled).toBe(true)
   })
 })

--- a/packages/ssg/test/ssg.test.ts
+++ b/packages/ssg/test/ssg.test.ts
@@ -1,6 +1,6 @@
 import type { SSGPlugin } from 'hono/ssg'
 import { build } from 'vite'
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
 import fs from 'node:fs'
 import path from 'node:path'
 import ssgPlugin from '../src/index'
@@ -83,22 +83,14 @@ describe('ssgPlugin', () => {
   })
 
   it('Should apply ssg plugins', async () => {
-    let beforeRequestCalled = false
-    let afterResponseCalled = false
-    let afterGenerateCalled = false
+    const beforeRequestHook = vi.fn((req) => req)
+    const afterResponseHook = vi.fn((res) => res)
+    const afterGenerateHook = vi.fn()
 
     const testPlugin: SSGPlugin = {
-      beforeRequestHook: (req) => {
-        beforeRequestCalled = true
-        return req
-      },
-      afterResponseHook: (res) => {
-        afterResponseCalled = true
-        return res
-      },
-      afterGenerateHook: () => {
-        afterGenerateCalled = true
-      },
+      beforeRequestHook,
+      afterResponseHook,
+      afterGenerateHook,
     }
 
     await build({
@@ -114,8 +106,8 @@ describe('ssgPlugin', () => {
       },
     })
 
-    expect(beforeRequestCalled).toBe(true)
-    expect(afterResponseCalled).toBe(true)
-    expect(afterGenerateCalled).toBe(true)
+    expect(beforeRequestHook).toHaveBeenCalled()
+    expect(afterResponseHook).toHaveBeenCalled()
+    expect(afterGenerateHook).toHaveBeenCalled()
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1181,7 +1181,7 @@ __metadata:
   resolution: "@hono/vite-ssg@workspace:packages/ssg"
   dependencies:
     glob: ^10.3.10
-    hono: ^4.2.7
+    hono: ^4.9.0
     publint: ^0.1.12
     rimraf: ^5.0.1
     tsup: ^7.2.0
@@ -3768,6 +3768,13 @@ __metadata:
   version: 4.6.12
   resolution: "hono@npm:4.6.12"
   checksum: a2690db239d6390efdc4080d2ac35155ad0f1f87c3f39ee56578fa3a8631e5dd173c31cff493588205b81a4fd19997f3ccffea19dd2f0b4040a65cc85b1f07e8
+  languageName: node
+  linkType: hard
+
+"hono@npm:^4.9.0":
+  version: 4.9.0
+  resolution: "hono@npm:4.9.0"
+  checksum: 1e4f34d3d622507dbd1107d029e5fe5861cc3d69b78e2f3f9fbe0a8bd42a6c700b3fadb748b73780c6fc24d694ae2f36b52969884a6480b454bb8e0224be81d3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1188,7 +1188,7 @@ __metadata:
     vite: ^6.1.1
     vitest: ^1.2.1
   peerDependencies:
-    hono: ">=4.0.0"
+    hono: ">=4.8.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This pull request adds an interface to accept ssg plugins, a feature introduced in Hono v4.8.0.

Note: Vite plugins and Hono SSG plugins can be very confusing due to their similar naming, so we should be careful with our wording to avoid misunderstandings.