### PR TITLE
feat(build/node): add optional graceful shutdown on SIGINT/SIGTERM

### DIFF
--- a/.changeset/graceful-shutdown.md
+++ b/.changeset/graceful-shutdown.md
@@ -1,0 +1,5 @@
+---
+"@hono/vite-build": minor
+---
+
+Added `shutdownTimeoutMs` option to the Node adapter for graceful shutdown on SIGINT/SIGTERM signals. Set to a timeout in milliseconds to enable graceful shutdown, or 0 to wait indefinitely for connections to close.

--- a/packages/build/src/adapter/node/index.ts
+++ b/packages/build/src/adapter/node/index.ts
@@ -6,10 +6,20 @@ import { serveStaticHook } from '../../entry/serve-static.js'
 export type NodeBuildOptions = {
   staticRoot?: string | undefined
   port?: number | undefined
+  /**
+   * Enable graceful shutdown on SIGINT and SIGTERM signals.
+   * Set to a number to specify the timeout in milliseconds before forcing shutdown.
+   * Set to 0 to wait indefinitely for connections to close.
+   * Leave undefined to disable graceful shutdown.
+   * @default undefined
+   */
+  shutdownTimeoutMs?: number | undefined
 } & BuildOptions
 
 const nodeBuildPlugin = (pluginOptions?: NodeBuildOptions): Plugin => {
   const port = pluginOptions?.port ?? 3000
+  const shutdownTimeoutMs = pluginOptions?.shutdownTimeoutMs
+
   return {
     ...buildPlugin({
       ...{
@@ -28,7 +38,21 @@ const nodeBuildPlugin = (pluginOptions?: NodeBuildOptions): Plugin => {
           async (appName) => {
             // eslint-disable-next-line quotes
             let code = "import { serve } from '@hono/node-server'\n"
-            code += `serve({ fetch: ${appName}.fetch, port: ${port.toString()} })`
+            if (shutdownTimeoutMs !== undefined) {
+              code += `const server = serve({ fetch: ${appName}.fetch, port: ${port.toString()} })\n`
+              code += 'const gracefulShutdown = () => {\n'
+              code += '  server.close(() => process.exit(0))\n'
+              if (shutdownTimeoutMs > 0) {
+                code += `  setTimeout(() => process.exit(1), ${shutdownTimeoutMs}).unref()\n`
+              }
+              code += '}\n'
+              // eslint-disable-next-line quotes
+              code += "process.on('SIGINT', gracefulShutdown)\n"
+              // eslint-disable-next-line quotes
+              code += "process.on('SIGTERM', gracefulShutdown)"
+            } else {
+              code += `serve({ fetch: ${appName}.fetch, port: ${port.toString()} })`
+            }
             return code
           },
         ],

--- a/packages/build/test/adapter.test.ts
+++ b/packages/build/test/adapter.test.ts
@@ -298,7 +298,10 @@ describe('Build Plugin with Node.js Adapter', () => {
     expect(output).toContain('use("/foo.txt"')
     expect(output).toContain('use("/js/*"')
     expect(output).toContain('use("/static/*", serveStatic({ root: "./" }))')
+    // graceful shutdown is disabled by default
     expect(output).toContain('serve({ fetch: mainApp.fetch, port: 3001 })')
+    expect(output).not.toContain('const server = serve')
+    expect(output).not.toContain('const gracefulShutdown')
 
     const outputFooTxt = readFileSync(`${testDir}/dist/foo.txt`, 'utf-8')
     expect(outputFooTxt).toContain('foo')
@@ -306,6 +309,50 @@ describe('Build Plugin with Node.js Adapter', () => {
     const outputJsClientJs = readFileSync(`${testDir}/dist/js/client.js`, 'utf-8')
     // eslint-disable-next-line quotes
     expect(outputJsClientJs).toContain("console.log('foo')")
+  })
+
+  it('Should build with graceful shutdown when shutdownTimeoutMs is set', async () => {
+    const outputFile = `${testDir}/dist/index.js`
+
+    await build({
+      root: testDir,
+      plugins: [
+        nodeBuildPlugin({
+          entry,
+          minify: false,
+          port: 3001,
+          shutdownTimeoutMs: 30000,
+        }),
+      ],
+    })
+
+    const output = readFileSync(outputFile, 'utf-8')
+    expect(output).toContain('const server = serve({ fetch: mainApp.fetch, port: 3001 })')
+    expect(output).toContain('const gracefulShutdown')
+    expect(output).toMatch(/process\.on\(['"]SIGINT['"], gracefulShutdown\)/)
+    expect(output).toMatch(/process\.on\(['"]SIGTERM['"], gracefulShutdown\)/)
+    // 30000 may be minified to 3e4
+    expect(output).toMatch(/setTimeout\(\(\) => process\.exit\(1\), (30000|3e4)\)\.unref\(\)/)
+  })
+
+  it('Should build with graceful shutdown and no timeout when shutdownTimeoutMs is 0', async () => {
+    const outputFile = `${testDir}/dist/index.js`
+
+    await build({
+      root: testDir,
+      plugins: [
+        nodeBuildPlugin({
+          entry,
+          minify: false,
+          shutdownTimeoutMs: 0,
+        }),
+      ],
+    })
+
+    const output = readFileSync(outputFile, 'utf-8')
+    expect(output).toContain('const gracefulShutdown')
+    expect(output).toMatch(/process\.on\(['"]SIGINT['"], gracefulShutdown\)/)
+    expect(output).not.toMatch(/setTimeout\(\(\) => process\.exit\(1\)/)
   })
 })
 


### PR DESCRIPTION
## Summary

- Adds `shutdownTimeoutMs` option to the Node adapter for graceful shutdown
- When set, registers SIGINT/SIGTERM handlers that call `server.close()` and exit cleanly
- Addresses #219

## Usage

```typescript
import node from '@hono/vite-build/node'

export default defineConfig({
  plugins: [
    node({
      entry: './src/index.ts',
      shutdownTimeoutMs: 10000,  // 10s timeout before force exit
    }),
  ],
})
```

Options:
- `undefined` (default): No graceful shutdown (existing behavior)
- `shutdownTimeoutMs: 10000`: Graceful shutdown with 10s timeout
- `shutdownTimeoutMs: 0`: Graceful shutdown, wait indefinitely

## Test plan

- [x] Added unit tests for all three behaviors
- [x] Manually tested with sample app - confirmed clean exit on SIGINT