### PR TITLE
fix(dev-server): use public `ssrModule` getter in `handleHotUpdate`

### DIFF
--- a/.changeset/wise-cobras-report.md
+++ b/.changeset/wise-cobras-report.md
@@ -1,0 +1,5 @@
+---
+'@hono/vite-dev-server': patch
+---
+
+fix: use public ssrModule getter in handleHotUpdate

--- a/packages/dev-server/README.md
+++ b/packages/dev-server/README.md
@@ -130,7 +130,7 @@ export const defaultOptions: Required<Omit<DevServerOptions, 'cf'>> = {
   ],
   ignoreWatching: [/\.wrangler/],
   handleHotUpdate: ({ server, modules }) => {
-    const isSSR = modules.some((mod) => mod._ssrModule)
+    const isSSR = modules.some((mod) => mod.ssrModule)
     if (isSSR) {
       server.hot.send({ type: 'full-reload' })
       return []

--- a/packages/dev-server/src/dev-server.ts
+++ b/packages/dev-server/src/dev-server.ts
@@ -80,7 +80,7 @@ export const defaultOptions: Required<Omit<DevServerOptions, 'env' | 'adapter' |
   ignoreWatching: [/\.wrangler/, /\.mf/],
   handleHotUpdate: ({ server, modules }) => {
     // Force reload the page if any of the modules is SSR
-    const isSSR = modules.some((mod) => mod._ssrModule)
+    const isSSR = modules.some((mod) => mod.ssrModule)
     if (isSSR) {
       server.hot.send({ type: 'full-reload' })
       return []


### PR DESCRIPTION
I noticed `(ssr) page reload` never appears when editing SSR modules, so there's no way to tell from the terminal if SSR reload is working. The page does reload, but only because Vite's HMR bubbles up as a fallback, not through the intended explicit `full-reload` path.

The cause is `handleHotUpdate` (#233 / #235) checking `mod._ssrModule`, a private internal field on Vite's compat ModuleNode. This replaces it with `mod.ssrModule`, the public getter that works across Vite 5 through 8. No compatibility concerns. Confirmed client modules are unaffected.