### PR TITLE
fix(dev-server): restore adapter paths

### DIFF
--- a/.changeset/bright-crabs-smoke.md
+++ b/.changeset/bright-crabs-smoke.md
@@ -1,0 +1,5 @@
+---
+'@hono/vite-dev-server': patch
+---
+
+fix: adapter paths

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -22,15 +22,15 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
-    "./adapter/bun": {
+    "./bun": {
       "import": "./dist/adapter/bun.mjs",
       "require": "./dist/adapter/bun.cjs"
     },
-    "./adapter/cloudflare": {
+    "./cloudflare": {
       "import": "./dist/adapter/cloudflare.mjs",
       "require": "./dist/adapter/cloudflare.cjs"
     },
-    "./adapter/node": {
+    "./node": {
       "import": "./dist/adapter/node.mjs",
       "require": "./dist/adapter/node.cjs"
     },


### PR DESCRIPTION
Fixes unintended breaking change in v0.25.2.

#351 renamed the adapter export keys from `./bun` / `./cloudflare` / `./node` to `./adapter/*` without a changeset, breaking existing imports when bumping to v0.25.2. 
@yusukebe I believe this was unintended.