### PR TITLE
fix(dev-server): include `.vite/*` to exclude list.

### DIFF
--- a/.changeset/small-goats-hug.md
+++ b/.changeset/small-goats-hug.md
@@ -1,0 +1,5 @@
+---
+'@hono/vite-dev-server': patch
+---
+
+fix: include `.vite/*` to exclude list.

--- a/packages/dev-server/src/dev-server.ts
+++ b/packages/dev-server/src/dev-server.ts
@@ -72,6 +72,7 @@ export const defaultOptions: Required<Omit<DevServerOptions, 'env' | 'adapter' |
     /^\/favicon\.ico$/,
     /^\/static\/.+/,
     /^\/node_modules\/.*/,
+    /^\/.vite\/.*/,
     /.*\.svelte$/,
     /.*\.vue$/,
     /.*\.js$/,

--- a/packages/dev-server/src/dev-server.ts
+++ b/packages/dev-server/src/dev-server.ts
@@ -72,7 +72,7 @@ export const defaultOptions: Required<Omit<DevServerOptions, 'env' | 'adapter' |
     /^\/favicon\.ico$/,
     /^\/static\/.+/,
     /^\/node_modules\/.*/,
-    /^\/.vite\/.*/,
+    /^\/\.vite\/.*/,
     /.*\.svelte$/,
     /.*\.vue$/,
     /.*\.js$/,


### PR DESCRIPTION
The default list of paths to exclude from the dev server does not include `.vite/*`, this works fine on Node/Bun environments but breaks on Deno.