### PR TITLE
feat(build): add amplify support

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -47,6 +47,10 @@
     "./vercel": {
       "types": "./dist/adapter/vercel/index.d.mts",
       "import": "./dist/adapter/vercel/index.mjs"
+    },
+    "./amplify": {
+      "types": "./dist/adapter/amplify/index.d.mts",
+      "import": "./dist/adapter/amplify/index.mjs"
     }
   },
   "author": "Yusuke Wada <yusuke@kamawada.com> (https://github.com/yusukebe)",

--- a/packages/build/src/adapter/amplify/index.ts
+++ b/packages/build/src/adapter/amplify/index.ts
@@ -1,0 +1,106 @@
+import type { Plugin, PluginOption, ResolvedConfig } from 'vite'
+import { existsSync, readFileSync } from 'node:fs'
+import { cp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { defaultOptions } from '../../base.js'
+import nodeBuildPlugin from '../node/index.js'
+import type { NodeBuildOptions } from '../node/index.js'
+
+export type Runtime = 'nodejs20.x' | 'nodejs22.x' | 'nodejs24.x'
+export type AmplifyBuildOptions = NodeBuildOptions & { runtime?: Runtime }
+
+const AMPLIFY_DIR = '.amplify-hosting'
+
+export default function amplifyBuildPlugin(options?: AmplifyBuildOptions): PluginOption {
+  const runtime = options?.runtime ?? 'nodejs22.x'
+  const outputFilename = options?.output ?? defaultOptions.output
+  let config: ResolvedConfig
+
+  const outputDir = options?.outputDir ?? './dist'
+  const nodePlugin = nodeBuildPlugin({
+    port: 3000,
+    staticRoot: outputDir,
+    ...options,
+  })
+
+  const amplifyPlugin: Plugin = {
+    name: '@hono/vite-build/amplify',
+    apply: options?.apply ?? defaultOptions.apply,
+
+    configResolved(resolvedConfig) {
+      config = resolvedConfig
+    },
+
+    async writeBundle() {
+      const resolvedOutputDir = resolve(config.root, options?.outputDir ?? config.build.outDir)
+      const amplifyDir = resolve(config.root, AMPLIFY_DIR)
+
+      await rm(amplifyDir, { recursive: true, force: true })
+      await mkdir(join(amplifyDir, 'compute', 'default'), { recursive: true })
+      await mkdir(join(amplifyDir, 'static'), { recursive: true })
+
+      await cp(
+        join(resolvedOutputDir, outputFilename),
+        join(amplifyDir, 'compute', 'default', outputFilename)
+      )
+
+      // Preserves /static/* URL structure that hono generates
+      const staticSrc = join(resolvedOutputDir, 'static')
+      if (existsSync(staticSrc)) {
+        await cp(staticSrc, join(amplifyDir, 'static', 'static'), { recursive: true })
+      }
+
+      if (existsSync(config.publicDir)) {
+        await cp(config.publicDir, join(amplifyDir, 'static'), { recursive: true })
+      }
+
+      await writeFile(
+        join(amplifyDir, 'deploy-manifest.json'),
+        generateManifest(runtime, outputFilename, getHonoVersion(config.root))
+      )
+    },
+  }
+
+  return [nodePlugin, amplifyPlugin]
+}
+
+function getHonoVersion(root: string): string {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(join(root, 'node_modules', 'hono', 'package.json'), 'utf-8')
+    )
+    return pkg.version ?? '0.0.0'
+  } catch {
+    return '0.0.0'
+  }
+}
+
+function generateManifest(runtime: Runtime, entrypoint: string, honoVersion: string): string {
+  return JSON.stringify(
+    {
+      version: 1,
+      framework: { name: 'hono', version: honoVersion },
+      routes: [
+        {
+          path: '/static/*',
+          target: {
+            kind: 'Static',
+            cacheControl: 'public, max-age=31536000, immutable',
+          },
+        },
+        {
+          path: '/*.*',
+          target: { kind: 'Static' },
+          fallback: { kind: 'Compute', src: 'default' },
+        },
+        {
+          path: '/*',
+          target: { kind: 'Compute', src: 'default' },
+        },
+      ],
+      computeResources: [{ name: 'default', runtime, entrypoint }],
+    },
+    null,
+    2
+  )
+}

--- a/packages/build/test/adapter.test.ts
+++ b/packages/build/test/adapter.test.ts
@@ -1,5 +1,6 @@
 import { build } from 'vite'
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import amplifyBuildPlugin from '../src/adapter/amplify'
 import bunBuildPlugin from '../src/adapter/bun'
 import cloudflarePagesPlugin from '../src/adapter/cloudflare-pages'
 import cloudflareWorkersPlugin from '../src/adapter/cloudflare-workers'
@@ -574,5 +575,91 @@ describe('Build Plugin with Vercel Adapter', () => {
         },
       })
     ).toThrow('`vercel.name` is required and cannot be empty.')
+  })
+})
+
+describe('Build Plugin with Amplify Adapter', () => {
+  const testDir = './test/mocks/app-static-files'
+  const amplifyDir = `${testDir}/.amplify-hosting`
+  const entry = './src/server.ts'
+
+  afterEach(() => {
+    rmSync(`${testDir}/dist`, { recursive: true, force: true })
+    rmSync(amplifyDir, { recursive: true, force: true })
+  })
+
+  it('Should build the project correctly with the plugin', async () => {
+    const outputFile = `${amplifyDir}/compute/default/index.js`
+    const manifestFile = `${amplifyDir}/deploy-manifest.json`
+
+    await build({
+      root: testDir,
+      plugins: [
+        amplifyBuildPlugin({
+          entry,
+          minify: false,
+        }),
+      ],
+    })
+
+    expect(existsSync(outputFile)).toBe(true)
+    expect(existsSync(manifestFile)).toBe(true)
+
+    const output = readFileSync(outputFile, 'utf-8')
+    expect(output).toContain('Hello World')
+    expect(output).toContain('serve(')
+
+    const manifest = JSON.parse(readFileSync(manifestFile, 'utf-8'))
+    expect(manifest.version).toBe(1)
+    expect(manifest.framework.name).toBe('hono')
+    expect(manifest.routes[0]).toEqual({
+      path: '/static/*',
+      target: { kind: 'Static', cacheControl: 'public, max-age=31536000, immutable' },
+    })
+    expect(manifest.routes[1]).toEqual({
+      path: '/*.*',
+      target: { kind: 'Static' },
+      fallback: { kind: 'Compute', src: 'default' },
+    })
+    expect(manifest.routes[2]).toEqual({ path: '/*', target: { kind: 'Compute', src: 'default' } })
+    expect(manifest.computeResources[0]).toEqual({
+      name: 'default',
+      runtime: 'nodejs22.x',
+      entrypoint: 'index.js',
+    })
+
+    const outputFooTxt = readFileSync(`${amplifyDir}/static/foo.txt`, 'utf-8')
+    expect(outputFooTxt).toContain('foo')
+  })
+})
+
+describe('Build Plugin with Amplify Adapter - with client build assets', () => {
+  const testDir = './test/mocks/app-static-files'
+  const amplifyDir = `${testDir}/.amplify-hosting`
+  const distDir = `${testDir}/dist`
+
+  beforeEach(() => {
+    // Simulate a prior client build that placed assets in dist/static/
+    mkdirSync(`${distDir}/static`, { recursive: true })
+    writeFileSync(`${distDir}/static/client.js`, 'console.log("client")')
+  })
+
+  afterEach(() => {
+    rmSync(distDir, { recursive: true, force: true })
+    rmSync(amplifyDir, { recursive: true, force: true })
+  })
+
+  it('Should copy client build assets to .amplify-hosting/static/static/', async () => {
+    await build({
+      root: testDir,
+      plugins: [
+        amplifyBuildPlugin({
+          entry: './src/server.ts',
+          minify: false,
+        }),
+      ],
+    })
+
+    expect(existsSync(`${amplifyDir}/static/static/client.js`)).toBe(true)
   })
 })


### PR DESCRIPTION
This pull request adds support for deploying to AWS Amplify Hosting in `@hono/vite-build`. This allows Hono and HonoX applications to be easily deployed to AWS Amplify's SSR compute environment.

Added an adapter for AWS Amplify Hosting (`@hono/vite-build/amplify`).

You can verify that an application built using HonoX is working at the following URL:
https://main.d3m99mj2upime6.amplifyapp.com/

## Usage

```ts
// vite.config.ts
import adapter from '@hono/vite-dev-server/node'
import amplifyBuild from '@hono/vite-build/amplify'
import honox from 'honox/vite'
import { defineConfig } from 'vite'

export default defineConfig({
  plugins: [
    honox({
      devServer: { adapter },
    }),
    amplifyBuild(),
  ],
})
```

The adapter generates the `.amplify-hosting` directory structure expected by Amplify Hosting (see [Amplify Hosting deployment specification](https://docs.aws.amazon.com/amplify/latest/userguide/ssr-deployment-specification.html)):

```
.amplify-hosting/
├── compute/
│   └── default/
│       └── index.js      # Server bundle
├── static/               # Public files (favicon, robots.txt, etc.)
│   └── static/           # Client build assets (/static/* URL structure)
└── deploy-manifest.json  # Amplify routing configuration
```

The following `amplify.yml` can be used to deploy:

```yaml
version: 1
frontend:
  phases:
    preBuild:
      commands:
        - npm install
    build:
      commands:
        - npm run build
  artifacts:
    baseDirectory: .amplify-hosting
    files:
      - '**/*'
  cache:
    paths:
      - node_modules/**/*
```
