### PR TITLE
chore: add bugs metadata for vite-build

### DIFF
--- a/.changeset/vite-build-bugs-metadata.md
+++ b/.changeset/vite-build-bugs-metadata.md
@@ -1,0 +1,5 @@
+---
+"@hono/vite-build": patch
+---
+
+Add bugs metadata for the vite-build package.

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -55,6 +55,9 @@
     "type": "git",
     "url": "https://github.com/honojs/vite-plugins.git"
   },
+  "bugs": {
+    "url": "https://github.com/honojs/vite-plugins/issues"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org",
     "access": "public"


### PR DESCRIPTION
## Summary

- add `bugs.url` metadata for `@hono/vite-build`
- point npm users and package tooling to the `honojs/vite-plugins` issue tracker

## Validation

- `npm view @hono/vite-build@1.11.1 name version repository homepage bugs --json`
- `node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('packages/build/package.json','utf8')); if (p.bugs?.url !== 'https://github.com/honojs/vite-plugins/issues') process.exit(1)"`
- `cd packages/build && npm pack --dry-run --ignore-scripts --json`
- `git diff --check`

## Notes

This is a metadata-only package manifest change. It does not change runtime code, dependencies, exports, generated files, or build behavior.
